### PR TITLE
Add jenkins + fastlane configurations

### DIFF
--- a/Development/Fastfile
+++ b/Development/Fastfile
@@ -1,0 +1,18 @@
+# Lanes to use in daily development for CI.
+
+default_platform(:ios)
+
+platform :ios do
+    # uses `versioning` plugin
+  desc "Update application build number with ci build number"
+  lane :set_build_number_from_ci do
+    increment_build_number_in_plist(
+      build_number: ci_build_number
+    )
+  end
+
+  desc "Increment application patch version number (#.#.x -> #.#.x+1)"
+  lane :increment_version_number_patch do
+    increment_version_number_in_plist
+  end
+end

--- a/Development/Fastfile
+++ b/Development/Fastfile
@@ -1,13 +1,67 @@
-# Lanes to use in daily development for CI.
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
 
+# Constants
+IPA_PATH = 'APP.ipa'
+XCODEPROJ = './APP.xcodeproj'
+WORKSPACE = 'APP.xcworkspace'
+
+# Variables
+@scheme = '' # debug scheme
+@note = '' # Note for
+@configuration = '' # debug configuration
+# env variable could be received from Jenkins build params
+if ENV['TARGET'] == 'staging'
+  #change if it's different env
+  @scheme = ''
+  @note = ''
+  @configuration = ''
+elsif ENV['TARGET'] == 'testflight'
+  @scheme = ''
+  @configuration = ''
+end
+
+# Configuration
 default_platform(:ios)
 
 platform :ios do
-    # uses `versioning` plugin
+  desc "Description of what the lane does"
+  lane :release do
+    # Bump build version
+    increment_build_number_in_plist(
+      build_number: ci_build_number,
+      scheme: @scheme,
+    )
+    # Build
+    gym(
+      clean: true,
+      workspace: WORKSPACE,
+      scheme: @scheme,
+      configuration: @configuration,
+      output_name: IPA_PATH,
+      export_method: 'enterprise',
+    )
+    # Deploy
+    if ENV['TARGET'] == 'testflight'
+      testflight(
+        ipa: IPA_PATH,
+      )
+    else
+      crashlytics(
+        build_secret: '', # get it from jenkins examples
+        api_token: '', # get it from jenkins examples
+        ipa_path: IPA_PATH,
+        groups: [], # define groups to receive builds
+        notes: @note,
+      )
+    end
+  end
+
+  # uses `versioning` plugin
   desc "Update application build number with ci build number"
   lane :set_build_number_from_ci do
     increment_build_number_in_plist(
-      build_number: ci_build_number
+      build_number: ci_build_number,
     )
   end
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Lint with [swiftlint.yml](Development/.swiftlint.yml).
 	1. [Git](Topics/Tools.md#git)
 	1. [Cocoapods](Topics/Tools.md#cocoapods)
 	1. [Swiftlint](Topics/Tools.md#swiftlint)
+1. [CI](Topics/CI.md)
+	1. [Jenkins](Topics/CI.md#jenkins)
+	1. [Fastlane](Topics/CI.md#fastlane)
 1. [Libraries](Topics/Libraries.md)
 1. [Examples](Examples/)
 

--- a/Topics/CI.md
+++ b/Topics/CI.md
@@ -4,10 +4,12 @@
 > [Home page](/README.md)
 
 ## Jenkins
+
 We have a jenkins CI servers. One server for one Xcode version.
 
 Any stage is defined with title:
-```
+
+```groovy
 stage('title') {
     // task
 }
@@ -16,33 +18,50 @@ stage('title') {
 Every build should have default configurations:
 
 Before main tasks:
-1. Fetch SCM
-1. Retrieve keychain values
+
+```groovy
+stage('SCM') { // 1. Fetch SCM
+    saritasa.git_clone(git_url, git_branch, git_user)
+}
+stage('keychain') { // 2. Fill keychain
+    ios.keychain_show_list()
+    ios.keychain_show_identity()
+    ios.keychain_unlock(ios.keychain_get_password('keychain-xcode'))
+}
+```
 
 After main tasks:
-1. Artifacts
-`archiveArtifacts artifacts: "*.ipa", fingerprint: true`
-1. Sonarqube
-` saritasa.sonarqube_scan('swift')`
 
+```groovy
+stage('artifacts') { // 1. Fill artifacts to fetch .ipa file later
+    archiveArtifacts artifacts: "*.ipa", fingerprint: true
+}
+stage('sonarqube') { // 2. Scan with sonarqube rules
+    saritasa.sonarqube_scan('swift')
+}
+```
+
+---
 
 ## Fastlane
+
 There is fastlane installed into jenkins. You could use it to define any lane inside your project and run on CI.
 
 Configurations:
+
 - [Increment build number from CI number](/Development/Fastfile)
 - [Increment build patch number (#.#.x)](/Development/Fastfile)
 
 Can be used in jenkins inside stage:
-```
+
+```groovy
 stage('fastlane lane') {
     // Wraps for a proper colorful output
     wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
         # define lane with sh script
-        sh(script: 'fastlane ios set_build_number_from_ci')
+        sh(script: 'fastlane ios lane')
     }
 }
 ```
-
 
 > [Home page](/README.md)

--- a/Topics/CI.md
+++ b/Topics/CI.md
@@ -49,8 +49,9 @@ There is fastlane installed into jenkins. You could use it to define any lane in
 
 Configurations:
 
-- [Increment build number from CI number](/Development/Fastfile)
-- [Increment build patch number (#.#.x)](/Development/Fastfile)
+- [Dev Beta/Staging Beta/Testflight release (with versioning plugin)](/Development/Fastfile)
+- [Increment build number from CI number (with versioning plugin)](/Development/Fastfile)
+- [Increment build patch number (#.#.x) (with versioning plugin)](/Development/Fastfile)
 
 Can be used in jenkins inside stage:
 

--- a/Topics/CI.md
+++ b/Topics/CI.md
@@ -1,0 +1,48 @@
+## Tools we use
+---
+
+> [Home page](/README.md)
+
+## Jenkins
+We have a jenkins CI servers. One server for one Xcode version.
+
+Any stage is defined with title:
+```
+stage('title') {
+    // task
+}
+```
+
+Every build should have default configurations:
+
+Before main tasks:
+1. Fetch SCM
+1. Retrieve keychain values
+
+After main tasks:
+1. Artifacts
+`archiveArtifacts artifacts: "*.ipa", fingerprint: true`
+1. Sonarqube
+` saritasa.sonarqube_scan('swift')`
+
+
+## Fastlane
+There is fastlane installed into jenkins. You could use it to define any lane inside your project and run on CI.
+
+Configurations:
+- [Increment build number from CI number](/Development/Fastfile)
+- [Increment build patch number (#.#.x)](/Development/Fastfile)
+
+Can be used in jenkins inside stage:
+```
+stage('fastlane lane') {
+    // Wraps for a proper colorful output
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
+        # define lane with sh script
+        sh(script: 'fastlane ios set_build_number_from_ci')
+    }
+}
+```
+
+
+> [Home page](/README.md)


### PR DESCRIPTION
Added some default lanes to use.
For now, it's only about build numbers.
Will add more configurations.

TODO:
- Upload to Testflight
- Upload to beta
- Increment version number from the one inside iTunes Connect. (to upload safely without any git tags/manual bumps)

@Saritasa/ios your rules are welcome.