### PR TITLE
Update swiftlint config

### DIFF
--- a/Development/.swiftlint.yml
+++ b/Development/.swiftlint.yml
@@ -1,31 +1,6 @@
-# Use `swiftlint autocorrect` for the first swiftlint run to remove simple warnings/errors
-
-disabled_rules:
-#  - vertical_whitespace # Should be enabled on new projects. BUT! Can cause a lot of warning on old projects with legacy code
-#  - trailing_whitespace # Should be enabled on new projects. BUT! Can cause a lot of warnings too. Can reduce file size. You can set it to be automatically managed in Xcode -> Preferences -> Text editing -> [v] Automatically trim trailing whitespace
-
-opt_in_rules:
-  - closure_end_indentation
-  - explicit_init
-  - overridden_super_call
-  - prohibited_super_call 
-  - redundant_nil_coalescing
-  - closure_spacing  
-  - operator_usage_whitespace
-  - empty_count # prefer .isEmpty over .count > 0
-  - first_where # .first(where:) over .filter().first
-  - contains_over_first_not_nil # .contains > .first(where:) != nil
-  - array_init # Array() is optimized. arr.map({ $0 }) is not
-  - sorted_first_last # .min/max preferred to .sorted().first/last
-  - private_action # @IBAction should be private
-  - private_outlet # @IBOutlet should be private
-  - yoda_condition # forbid if 42 == value
-  - discouraged_optional_boolean # warn about optional booleans. Use enums instead
-  #  - file_header # - this should be used when we need file headers of one-type (copyright, date, other info)
 excluded:
   - Pods
-# Optional: Generated files
-# - Generated 
+  - R.generated.swift
 
 # rules configuration
 indentation: 4 # 4 spaces
@@ -37,13 +12,11 @@ line_length:
   ignores_urls:
     true
 file_length:
-  - 500
+  - 1000
   - 2500
 type_body_length:
-  - 750 # warning
+  - 1000 # warning
   - 1500 # error
-force_cast: warning
-force_try: warning
 function_body_length:
   - 200 # warning
   - 400 # error
@@ -53,7 +26,13 @@ function_parameter_count:
 cyclomatic_complexity:
   - 20 # warning
   - 40 # error
-shorthand_operator: warning
-large_tuple: 
+large_tuple:
   - 3 # warning
   - 5 # error
+
+disabled_rules:
+  - force_cast
+  - force_try
+  - nesting
+  - identifier_name
+  - opening_brace


### PR DESCRIPTION
Justification of disabled rules:
- `force_cast` and `force_try` – usually we know what we're doing :)
- `nesting` – sometimes it's convenient to have nesting for types more than one level.
- `identifier_name` – short names are ok in methods and functions. Nobody writes short names for top level.
- `opening_brace` – starting from v0.45 of swiftformat it formats curly braces on new lines in cases where definitions or calls span on multiple lines (long method names, etc.)